### PR TITLE
User can see specific article (revisited)

### DIFF
--- a/spec/features/user_can_see_specific_article_spec.rb
+++ b/spec/features/user_can_see_specific_article_spec.rb
@@ -6,15 +6,22 @@ feature 'User can see a specific article' do
         create(:article, title: 'Broken news!', content: 'Today, some broken news was found in a back garden')
 
         visit root_path
-        click_on 'Breaking news!'
     end
+    
+    it 'User sees list of articles' do
+        expect(page).to have_content 'Broken news!'
+    end
+        
+    context 'When article is clicked' do
+        before do
+            click_on 'Breaking news!'
+        end
 
-    context 'Article displays' do
-        it 'title' do
+        it 'article title is displayed' do
             expect(page).to have_content 'Breaking news!'
         end
         
-        it 'content' do
+        it 'article content is displayed' do
             expect(page).to have_content 'Look at all these people breaking todays news.'
         end
     end


### PR DESCRIPTION
Merging this again because I re-wrote the spec so that it gives a bit more information. The user_can_create_article branch is in some way having problem with this spec, so this change is in order to figure out where it goes wrong.